### PR TITLE
adding SURVIVOR updates

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,30 @@
+FROM ubuntu:xenial
+MAINTAINER Alexander Paul <alex.paul@wustl.edu>
+
+LABEL \
+  version="1.0.6.2" \
+  description="SURVIVOR image to be used in cwl workflows"
+
+RUN apt-get update && apt-get install -y \
+  g++ \
+  make \
+  gzip \
+  wget
+
+ENV SURVIVOR_INSTALL_DIR=/opt/SURVIVOR
+ENV SURVIVOR_VERSION=1.0.6.2
+
+WORKDIR /tmp
+RUN wget https://github.com/apaul7/SURVIVOR/archive/v$SURVIVOR_VERSION.tar.gz && \
+  tar -zxf v$SURVIVOR_VERSION.tar.gz
+
+WORKDIR /tmp/SURVIVOR-$SURVIVOR_VERSION/Debug
+RUN make && \
+  mkdir --parents $SURVIVOR_INSTALL_DIR && \
+  mv ./* $SURVIVOR_INSTALL_DIR
+
+WORKDIR /
+RUN ln -s $SURVIVOR_INSTALL_DIR/SURVIVOR /usr/bin/SURVIVOR && \
+  rm -rf /tmp/SURVIVOR-$SURVIVOR_VERSION/
+
+COPY survivor_merge_helper.sh /usr/bin/survivor_merge_helper.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,8 @@ RUN apt-get update && apt-get install -y \
   g++ \
   make \
   gzip \
-  wget
+  wget \
+  zlib1g-dev
 
 ENV SURVIVOR_INSTALL_DIR=/opt/SURVIVOR
 ENV SURVIVOR_VERSION=1.0.6.2

--- a/survivor_merge_helper.sh
+++ b/survivor_merge_helper.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+set -o pipefail
+set -o errexit
+set -o nounset
+
+# uncompress files as needed
+for i in $(echo ${1} | tr "," "\n"); do
+    if [[ $i == *.gz ]]; then
+        cp "$i" .
+        name=$(basename "$i")
+        gunzip "$name"
+        name=$(echo "$name" | sed 's/\(.*\)\.gz/\1/')
+        i="$(pwd)/$name"
+    fi
+    echo "$i" >> vcfs.list
+done
+
+/usr/bin/SURVIVOR merge vcfs.list ${2} ${3} ${4} ${5} ${6} ${7} ${8}


### PR DESCRIPTION
This adds some of the latest SURVIVOR updates to the docker image. There still is not a new release so have to still use my fork of the SURVIVOR.
Main thing is that it now creates a correctly formatted VCF. previously it failed to accommodate the extra `:`s found in certain fields. Which then would cause some downstream tools to fail.

Also merging this to master and will then make a branch for 1.0.6.2